### PR TITLE
Strict running of scripts

### DIFF
--- a/actions/build-orm-zip/entrypoint.sh
+++ b/actions/build-orm-zip/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 apt-get update
 apt install -y build-essential zip
 

--- a/actions/create-image/entrypoint.sh
+++ b/actions/create-image/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 apt-get update
 apt install -y jq unzip
 

--- a/actions/terraform-apply/entrypoint.sh
+++ b/actions/terraform-apply/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 apt-get update
 apt install -y build-essential unzip go-dep

--- a/actions/terraform-apply/entrypoint.sh
+++ b/actions/terraform-apply/entrypoint.sh
@@ -7,7 +7,6 @@ apt install -y build-essential unzip go-dep
 #Installing terraform and upgrading code to Terraform 12
 wget -q https://releases.hashicorp.com/terraform/0.12.10/terraform_0.12.10_linux_amd64.zip
 unzip terraform_0.12.10_linux_amd64.zip -d /usr/bin
-cd ${GITHUB_WORKSPACE}/terraform
 terraform init
 
 #Set up environment for running terratest in go

--- a/actions/update-listing/entrypoint.sh
+++ b/actions/update-listing/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 echo "${API_CREDS}" > ${GITHUB_WORKSPACE}/api_creds.yaml
 


### PR DESCRIPTION
Resolves #20 

Added strict checking ("set -e") to the beginning of the entrypoint.sh scripts. The code was in good shape and I only needed to remove one spurious "cd" command to get all actions to run to completion.

Can someone merge to master @dbcopas  @cpoczatek  @benofben ? This change was tested on the "testing_branch" of the h2o repo with a successful run of all actions. See the following log:

  https://github.com/oracle-quickstart/oci-h2o/runs/610794932?check_suite_focus=true

PS: Remember to check the "Delete branch" button upon merging.