### PR TITLE
remove release date from metadata. compact timestamp

### DIFF
--- a/actions/update-listing/mpctl.py
+++ b/actions/update-listing/mpctl.py
@@ -67,8 +67,6 @@ class ListingMetadata:
             self.api_metadata['listingId'] = args.listingId
             self.api_metadata['versionDetails']['versionNumber'] = lvd['versionDetails']['versionNumber'] \
                 if 'versionDetails' in lvd and 'versionNumber' in lvd['versionDetails'] else ''
-            self.api_metadata['versionDetails']['releaseDate'] = lvd['versionDetails']['releaseDate'] \
-                if 'versionDetails' in lvd and 'releaseDate' in lvd['versionDetails'] else ''
             self.api_metadata['name'] = lvd['name'] if 'name' in lvd else ''
             self.api_metadata['shortDescription'] = lvd['shortDescription'] if 'shortDescription' in lvd else ''
             self.api_metadata['longDescription'] = lvd['longDescription'] if 'longDescription' in lvd else ''


### PR DESCRIPTION
uses shorter timestamp
removes release data from generated metadata
uses current time on new listing creation
closes #12 , closes #14 
